### PR TITLE
Use node runtime version lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ We tried `Lambda's error metric + CloudWatch Alarm + Chatbot` and `CloudWatch Me
 
 ## FAQ
 
+### Running project tests
+
+To execute tests locally, run the following commands:
+
+```bash
+npm install
+npm run test
+```
+
+To update test snapshots, run:
+
+```bash
+npm run test -- -u
+```
+
 ### Cross Stack?
 
 Possible. Export all values in `LogNotifier.prototype.attributes`, import it and use `LogNotifier.fromAttributes()` in another Stack.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -85,7 +85,7 @@ export class LogNotifier extends LogNotifierImpl {
     this.filterPattern = props.filterPattern;
     this.handleLogFunc = new lambda.Function(this, 'LogHandler', {
       code: lambda.Code.fromAsset(path.join(__dirname, 'lambda-log-handler')),
-      runtime: lambda.Runtime.NODEJS_LATEST,
+      runtime: lambda.determineLatestNodeRuntime(this),
       handler: 'index.handler',
       environment: {
         'RESOLVED_DATETIME_FORMAT_OPTIONS': JSON.stringify(dateTimeFormat.resolvedOptions()),

--- a/tests/__snapshots__/snapshot.test.ts.snap
+++ b/tests/__snapshots__/snapshot.test.ts.snap
@@ -298,7 +298,15 @@ exports[`snapshot test 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": {
+          "Fn::FindInMap": [
+            "LatestNodeRuntimeMap",
+            {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },


### PR DESCRIPTION
This uses `lambda.determineLatestNodeRuntime` to get the Lambda runtime version.

Resolves: https://github.com/TheDesignium/cdk-log-notifier/issues/16